### PR TITLE
Fix missing brackets in wh_ratio_in_range

### DIFF
--- a/boxdetect/rect_proc.py
+++ b/boxdetect/rect_proc.py
@@ -129,7 +129,7 @@ def wh_ratio_in_range(c, wh_ratio_range, tolerance=0.05):
     """ # NOQA E501
     (x, y, w, h, is_rect) = get_bounding_rect(c)
     ar = w / float(h)
-    if is_rect and ar >= wh_ratio_range[0] * 1 - tolerance and ar <= wh_ratio_range[1] * 1 + tolerance:  # NOQA E501
+    if is_rect and ar >= wh_ratio_range[0] * (1 - tolerance) and ar <= wh_ratio_range[1] * (1 + tolerance):  # NOQA E501
         return True
     return False
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ bump2version
 pyyaml
 pytest
 pytest-cov
-sklearn
+scikit-learn


### PR DESCRIPTION
Currently wh ratio is multiplied by 1 which does nothing and then the tolerance value is linearly added and substracted instead of multiplied.